### PR TITLE
Update watch.js to work with windows git bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To run the code in this repository, install [Node.js](http://nodejs.org). Then:
 
 * Use `./build.sh quick` or `./watch.sh quick` to perform an incremental build, and `./clean.sh` to reset the incremental build.
 
-* On Windows, use `build` or `build quick` to perform a build. Sorry, the watch script doesn't work on Windows.
+* On Windows, use `build` or `build quick` to perform a build. use `watch` to run tests every time a file changes.  If you are using gitbash on windows you can use the above mentioned *.sh files which will work and display the output better.
 
 All commands must be run from the repository root.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To run the code in this repository, install [Node.js](http://nodejs.org). Then:
 
 * Use `./build.sh quick` or `./watch.sh quick` to perform an incremental build, and `./clean.sh` to reset the incremental build.
 
-* On Windows, use `build` or `build quick` to perform a build. use `watch` to run tests every time a file changes.  If you are using gitbash on windows you can use the above mentioned *.sh files which will work and display the output better.
+* On Windows, use `build` or `build quick` to perform a build. Use `watch` to run tests every time a file changes.  If you are using gitbash on windows you can use the above mentioned *.sh files which will work and display the output better.
 
 All commands must be run from the repository root.
 

--- a/build/scripts/watch.js
+++ b/build/scripts/watch.js
@@ -104,8 +104,8 @@ function alertBuildResult(buildResult) {
 
 function flushCaches() {
 	Object.keys(require.cache).forEach((key) => {
-		const srcDirPrefix = pathLib.resolve("./src");
-		const nodeModulesPrefix = pathLib.resolve("./node_modules");
+		const srcDirPrefix = pathLib.resolve("./src") + pathLib.sep;
+		const nodeModulesPrefix = pathLib.resolve("./node_modules") + pathLib.sep;
 
 		if (key.startsWith(srcDirPrefix) || key.startsWith(nodeModulesPrefix)) delete require.cache[key];
 	});

--- a/build/scripts/watch.js
+++ b/build/scripts/watch.js
@@ -104,8 +104,8 @@ function alertBuildResult(buildResult) {
 
 function flushCaches() {
 	Object.keys(require.cache).forEach((key) => {
-		const srcDirPrefix = pathLib.resolve("./src") + "/";
-		const nodeModulesPrefix = pathLib.resolve("./node_modules") + "/";
+		const srcDirPrefix = pathLib.resolve("./src");
+		const nodeModulesPrefix = pathLib.resolve("./node_modules");
 
 		if (key.startsWith(srcDirPrefix) || key.startsWith(nodeModulesPrefix)) delete require.cache[key];
 	});

--- a/watch.cmd
+++ b/watch.cmd
@@ -1,0 +1,8 @@
+@echo off
+call build\scripts\prebuild
+goto watchLoop
+:restart
+echo "Restarting ..."
+:watchLoop
+node build/scripts/watch.js
+if %ERRORLEVEL% EQU 0 goto restart


### PR DESCRIPTION
In git bash with `const srcDirPrefix = pathLib.resolve("./src")`  it was resolving to `'C:\\projects\\livestream\\src'` when adding the trailing '/' the key it was trying to delete would be `C:\projects\\livestream\\src/` which didn't exist, but if you remove the trailing slash it does exist.

On my windows environment it was trying to remove `C:\\projects\\livestream\\src\\__my_test.js` from the cache but since that doesn't have a prefix of `C:\\projects\livestream\\src/` it was not be removed.

Looking at the code it appears that the trailing slash shouldn't matter unless you have another folder/file who's cache you don't want deleted that starts with `src` or `node_modules` so this shouldn't be run into in practice.

I have not been able to test this on a linux or mac os so you may want to try it out before merging it.