### PR TITLE
Add Linux sound support

### DIFF
--- a/build/scripts/watch.js
+++ b/build/scripts/watch.js
@@ -142,6 +142,9 @@ async function playSoundAsync(filename) {
 			// If on Windows create a Media.SoundPlayer .Net object to play the sound, it is invoked through powershell
 			// note that Media.SoundPlayer has a restriction of only working on .wav files.
 			await sh.runSilentlyAsync(`powershell`,['-c',`(New-Object Media.SoundPlayer "${path}").PlaySync();`]);
+    } else if (process.platform === 'linux'){
+      // aplay is part of the alsa-utils package
+      await sh.runSilentlyAsync("aplay", [ path ]);
 		} else {
 			// Designed for MacOS, which has built-in 'afplay' command
 			await sh.runSilentlyAsync("afplay", [ path ]);


### PR DESCRIPTION
Add Linux sound support.  ALSA sound is pretty standard on Linux distros, and aplay is a simple command line player.